### PR TITLE
Normalizing preference index

### DIFF
--- a/HTML_DTS_project.R
+++ b/HTML_DTS_project.R
@@ -27,7 +27,7 @@ library(knitr)
 library(dabestr)
 library(zoo)
 library(tidyverse)
-
+library(shiny)
 ## source the script with the functions needed for analysis
 source("readXMLdatafile.R")
 source("DTS_plotfunctions.R")

--- a/single_fly.Rmd
+++ b/single_fly.Rmd
@@ -492,3 +492,44 @@ cat("\n# Learning and avoidance scores\n")
             col = as.vector(na.omit(sequence$color)))
 ```
 
+# Performance Index {.tabset}
+## Not normalized Preference Index
+```{r, echo=FALSE}
+
+n = pretest = 1
+
+#use a while loop to save the pretest values
+while (sequence$outcome[n] == 0) {
+  pretest[n] = sequence$lambda[n]
+  n = n+1
+}
+
+
+sequence$normalized = sequence$lambda-(mean(pretest)) #subtract the PI values from the pretest
+
+#use a for loop to cap the maximum PI to 1
+n=1
+for(n in 1:length(sequence$normalized)){
+  if (sequence$normalized[n] > 1){sequence$normalized[n] = 1}
+
+}
+
+max = round(max(test$lambda)) #set ylim
+
+      barplot(as.vector(na.omit(test$lambda)), main = paste("Performance Indices (not normalized)", flyname),
+            xlab="Time [periods]",
+            ylab="PI [rel. units]",
+            space=0,
+            ylim=c(0,max),
+            col = as.vector(na.omit(test$color)))
+```
+
+## Normalized Preference Index
+```{r, echo=FALSE}
+      barplot(as.vector(na.omit(test$normalized)), main = paste("Performance Indices (normalized", flyname),
+            xlab="Time [periods]",
+            ylab="PI [rel. units]",
+            space=0,
+            ylim=c(0,max),
+            col = as.vector(na.omit(test$color)))
+```


### PR DESCRIPTION
I implemented it into the single fly analysis. The code calculates the pretest and subtracts it from the performance index. However, assume that we have a pretest of -0.2, and the preference index is 0.85. Normalizing the PI against the pretest would then result in a PI greater than 1? I "solved" this by capping the maximum PI to 1. How did you solve this issue in your code?